### PR TITLE
 removed clear Bookmarks button inside of modal when empty

### DIFF
--- a/src/components/Autocomplete/SavedPlaces.js
+++ b/src/components/Autocomplete/SavedPlaces.js
@@ -84,13 +84,15 @@ const SavedPlaces = ({display, setUpdateIcon}) => {
       >          
         <h1>Saved Locations</h1>
         
+        { cities.length > 0 &&
         <button style={{
         background: "none",
         border: "none",
         textDecoration: "underline",
         color: "#000",
         cursor: "pointer"}}
-        onClick={() => handleRemove()}>Clear Bookmarks</button>        
+        onClick={() => handleRemove()}>Clear Bookmarks</button> 
+        }       
         {
           cities.length === 0?
           <h2 style={{


### PR DESCRIPTION
-Removed the clear Bookmarks button in the modal when the localStorage is empty
-Problem was that it would cause a bug if left inside the modal and clicked multiple times